### PR TITLE
fix: consistent master password key storage (fixes #7)

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -130,7 +130,7 @@ export class SyncManager {
         await this.loadConfig();
 
         // Load master password from secrets
-        const storedPassword = await this.context.secrets.get(`${EXT_NAME}.sync.masterPassword`);
+        const storedPassword = await this.context.secrets.get('ag-sync-master-password');
         if (storedPassword) {
             this.masterPassword = storedPassword;
         }


### PR DESCRIPTION
Fixes #7. The extension was storing the password with key 'ag-sync-master-password' but trying to read it with 'antigravity-storage-manager.sync.masterPassword'. This PR unifies the key to 'ag-sync-master-password'.