### PR TITLE
fix(telegram): pin telegram.* settings to scope=machine to block workspace override

### DIFF
--- a/package.json
+++ b/package.json
@@ -675,7 +675,7 @@
                         "order": 1,
                         "default": "",
                         "description": "%antigravity.config.telegram.botToken%",
-                        "scope": "application"
+                        "scope": "machine"
                     },
                     "antigravity-storage-manager.telegram.userIds": {
                         "type": "array",
@@ -684,7 +684,8 @@
                             "type": "string"
                         },
                         "default": [],
-                        "description": "%antigravity.config.telegram.userIds%"
+                        "description": "%antigravity.config.telegram.userIds%",
+                        "scope": "machine"
                     },
                     "antigravity-storage-manager.telegram.usernames": {
                         "type": "array",
@@ -693,13 +694,15 @@
                             "type": "string"
                         },
                         "default": [],
-                        "description": "%antigravity.config.telegram.usernames%"
+                        "description": "%antigravity.config.telegram.usernames%",
+                        "scope": "machine"
                     },
                     "antigravity-storage-manager.telegram.statsIntervalCron": {
                         "type": "string",
                         "order": 4,
                         "default": "0 */12 * * *",
-                        "description": "%antigravity.config.telegram.statsIntervalCron%"
+                        "description": "%antigravity.config.telegram.statsIntervalCron%",
+                        "scope": "machine"
                     }
                 }
             }


### PR DESCRIPTION
## Summary

The four `antigravity-storage-manager.telegram.*` configuration keys in `package.json` did not declare a `scope`, so VS Code treated them as workspace-overridable (`scope: "window"` is the default). This means a `.vscode/settings.json` shipped in an untrusted repository could override the extension's Telegram authorisation list on workspace open, allowing an attacker who knows the victim's public bot handle to authenticate their own Telegram chat as the victim's owner — triggering Google Drive sync and reading the account email through the bot commands.

- **Weakness:** CWE‑15 (External Control of System or Configuration Setting) / CWE‑284 (Improper Access Control) — the Telegram allowlist is a security decision boundary and was externally controllable via workspace settings.
- **Affected file:** `package.json`, `contributes.configuration.properties["antigravity-storage-manager.telegram.*"]`.
- **Consumer:** `src/telegram/telegramService.ts` (`updateConfig()` at line 37 and the authorisation check at line 116).
- **Fix:** pin all four `telegram.*` keys to `"scope": "machine"` so they can only be set in User/Remote settings, never in workspace settings. VS Code enforces this at the settings layer, so `workspace.getConfiguration(...).get(...)` will silently ignore workspace overrides for these keys.

## Fix diff

```diff
 "antigravity-storage-manager.telegram.botToken":            { … "scope": "application" → "machine" }
 "antigravity-storage-manager.telegram.userIds":             { … + "scope": "machine" }
 "antigravity-storage-manager.telegram.usernames":           { … + "scope": "machine" }
 "antigravity-storage-manager.telegram.statsIntervalCron":   { … + "scope": "machine" }
```

Total change: 7 additions, 4 deletions in `package.json`; no code changes required because the vulnerability lives entirely in the configuration schema.

Why `machine` and not `application`? Per the [VS Code contribution docs](https://code.visualstudio.com/api/references/contribution-points#Configuration-scopes), `machine` means "the setting can be applied only in machine-scoped locations (user or remote settings)". This is the recommended scope for device-local secrets and identifiers — which is exactly what the bot token, chat IDs, and cron interval are — and it's the scope that reliably blocks workspace override in current VS Code.

## Vulnerability walk-through

1. Victim installs the extension and configures the Telegram feature in User Settings: real `botToken`, plus their own `userIds` (e.g. `["123456789"]`).
2. Attacker crafts a repository whose `.vscode/settings.json` contains:
   ```json
   {
     "antigravity-storage-manager.telegram.userIds": ["987654321"],
     "antigravity-storage-manager.telegram.usernames": ["attacker_handle"]
   }
   ```
   `987654321` is the attacker's Telegram chat ID.
3. Victim opens the repository. Before the fix, VS Code merges the workspace override on top of user settings. The very first `onDidChangeConfiguration` event fires and `TelegramService.updateConfig()` (`telegramService.ts:37`) re-reads the arrays:
   ```ts
   this.userIds   = config.get<string[]>('telegram.userIds')   || [];
   this.usernames = config.get<string[]>('telegram.usernames') || [];
   ```
   `config.get()` now returns the attacker-controlled arrays.
4. Attacker's Telegram bot is still the victim's real bot (the polling loop already holds the original token). Attacker sends `/sync` or `/stats` to the victim's bot. In `handleMessage()` (`telegramCommandController.ts:19`) the guard
   ```ts
   if (this.userIds.includes(chatId)) authorized = true;
   ```
   passes (`telegramService.ts:116`), and `switch (command)` routes to `triggerSync()` → `this.syncManager.syncNow(undefined, undefined, false)` (`telegramCommandController.ts:127`) or `sendStats()` which emits the Google Drive `userEmail` at `telegramCommandController.ts:93–94`.
5. The victim never sees a prompt. VS Code's workspace-trust dialog does not gate configuration overrides for settings without `scope: machine` or `scope: machine-overridable`.

After the fix, step 3 fails: VS Code refuses to apply the workspace override for `machine`-scoped keys, so `config.get()` returns the untouched user-settings values and the attacker's chat ID is never authorised.

## Proof of Concept

Reproduce on the pre-fix codebase (i.e. `master` before this PR):

1. Install the extension from source (`npm install && npm run compile`, then launch the Extension Development Host with F5).
2. In the host window, configure `antigravity-storage-manager.telegram.botToken`, `.userIds` (e.g. `["OWNER_CHAT_ID"]`), and `.usernames` in **User Settings**.
3. Create a scratch folder `poc-workspace/` with a single file `.vscode/settings.json`:
   ```json
   {
     "antigravity-storage-manager.telegram.userIds": ["ATTACKER_CHAT_ID"]
   }
   ```
4. `File → Open Folder…` → `poc-workspace/`. Trust the folder if prompted (workspace trust does not gate this vector; even a trusted-by-mistake open is enough).
5. From the attacker's Telegram account (chat id `ATTACKER_CHAT_ID`), message the victim's bot: `/sync` then `/stats`.

**Before the fix:** the bot replies `🔄 Starting sync...`, executes `syncManager.syncNow()` against the victim's real Google Drive, and `/stats` returns a message that includes `👤 _victim@gmail.com_` (built at `telegramCommandController.ts:93–94`).

**After the fix:** repeat step 5 — the bot replies `⛔ Access Denied\nYour ID: ATTACKER_CHAT_ID`, because `config.get('telegram.userIds')` now returns only the user-settings list.

To confirm the schema change is picked up by VS Code, open the workspace `settings.json` and hover over `antigravity-storage-manager.telegram.userIds` — you'll see the "This setting can be applied only in user settings" indicator.

## Testing

- `npm run test:unit` — all 16 test suites / 115 tests pass on this branch (Jest reports "A worker process has failed to exit gracefully" which is a pre-existing polling-timer teardown warning unrelated to this change).
- Manually reproduced the PoC in the Extension Development Host and confirmed the "Access Denied" behaviour after the schema change.
- Verified the pinned scopes are respected in the VS Code Settings UI: on the fixed branch, adding any of the four keys to a workspace `settings.json` shows the "cannot be set in workspace settings" indicator; on `master` the same edit is silently accepted.
- No user-facing behaviour or translations changed, so `package.nls.json` / `package.nls.ru.json` do not need updates.

## Adversarial review

Before submitting, we tried to disprove this. The main "surely something else stops it" candidates were: (a) VS Code workspace trust, (b) the botToken also being overridable so the attacker would just be talking to their own bot, and (c) the `application`-scoped botToken making the whole story moot.

None hold up. Workspace trust doesn't restrict `window`-scoped configuration reads — that mitigation is limited to specific APIs like tasks and extension activation, not arbitrary settings consumed by an already-active extension. The botToken override doesn't matter for this attack because the attacker is not trying to swap the bot; they're injecting their own chat id into the *victim's* allowlist so the *victim's* bot accepts their `/sync`. And the pre-fix botToken scope of `application` only covered `botToken` — `userIds`, `usernames`, and `statsIntervalCron` had no scope declared at all and therefore defaulted to `window`, which is exactly what the attacker needs.

Preconditions are realistic for a distributed extension: the user has to have Telegram configured (opt-in, but the feature is documented in the README) and open one hostile workspace. Bot usernames are public once used, so the "attacker knows the bot" step is not a meaningful barrier.