### PR TITLE
fix(proxy): use CSPRNG for generated proxy API keys (CWE-338)

### DIFF
--- a/src/proxy/proxyManager.ts
+++ b/src/proxy/proxyManager.ts
@@ -495,7 +495,11 @@ ${keyConfig}
     }
 
     public generateApiKey(): string {
-        const key = 'sk-' + Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+        // Use nodeCrypto to generate a cryptographically strong API key.
+        // Math.random() is not a CSPRNG and its state (V8 xorshift128+)
+        // can be recovered from observed outputs, allowing an attacker to
+        // predict subsequent API keys used to authenticate against the proxy.
+        const key = 'sk-antigravity-' + nodeCrypto.randomBytes(24).toString('hex');
         try {
             const configPath = path.join(this._binDir, 'config.yaml');
             if (!fs.existsSync(configPath)) {

--- a/src/test/unit/proxyManagerApiKey.test.ts
+++ b/src/test/unit/proxyManagerApiKey.test.ts
@@ -1,0 +1,120 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+// Mock vscode module (identical shape to the existing proxyManager test)
+jest.mock('vscode', () => ({
+    l10n: {
+        t: (str: string, ...args: any[]) => str.replace(/\{(\d+)\}/g, (_, i) => args[i] ?? '')
+    },
+    window: {
+        showInformationMessage: jest.fn(),
+        showErrorMessage: jest.fn(),
+        showWarningMessage: jest.fn(),
+        withProgress: jest.fn((options, task) => task({ report: jest.fn() }, undefined)),
+        createOutputChannel: jest.fn(() => ({
+            append: jest.fn(),
+            appendLine: jest.fn(),
+            show: jest.fn(),
+            dispose: jest.fn()
+        })),
+        createStatusBarItem: jest.fn(() => ({
+            show: jest.fn(),
+            hide: jest.fn(),
+            dispose: jest.fn(),
+            text: '',
+            command: '',
+            backgroundColor: undefined
+        }))
+    },
+    workspace: {
+        getConfiguration: jest.fn(() => ({
+            get: jest.fn((key: string, defaultValue: any) => defaultValue),
+            update: jest.fn()
+        }))
+    },
+    StatusBarAlignment: { Right: 1 },
+    ThemeColor: jest.fn(),
+    EventEmitter: class {
+        event = jest.fn();
+        fire = jest.fn();
+        dispose = jest.fn();
+    },
+    commands: {
+        registerCommand: jest.fn()
+    }
+}), { virtual: true });
+
+import { ProxyManager } from '../../proxy/proxyManager';
+
+describe('ProxyManager.generateApiKey (CWE-338 fix)', () => {
+    let context: any;
+    let tmpDir: string;
+    let pm: ProxyManager;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agsm-pm-'));
+        // Pre-create bin dir so generateApiKey can write config.yaml
+        fs.mkdirSync(path.join(tmpDir, 'bin'), { recursive: true });
+        context = {
+            subscriptions: [],
+            secrets: { get: jest.fn(), store: jest.fn(), delete: jest.fn() },
+            extensionUri: { fsPath: '/mock/path' }
+        };
+        pm = new ProxyManager(context, tmpDir);
+    });
+
+    afterEach(() => {
+        try { pm.dispose(); } catch { /* noop */ }
+        try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* noop */ }
+    });
+
+    test('key has expected sk-antigravity- prefix and 48 hex chars', () => {
+        const key = pm.generateApiKey();
+        expect(key).not.toBe('');
+        expect(key.startsWith('sk-antigravity-')).toBe(true);
+        const body = key.substring('sk-antigravity-'.length);
+        expect(body).toMatch(/^[0-9a-f]{48}$/);
+    });
+
+    test('does not use predictable Math.random format (alphabet is hex only)', () => {
+        const key = pm.generateApiKey();
+        const body = key.substring('sk-antigravity-'.length);
+        expect(body).not.toMatch(/[g-z]/); // hex has no g-z
+    });
+
+    test('generates unique high-entropy keys across many invocations', () => {
+        const seen = new Set<string>();
+        const N = 200;
+        for (let i = 0; i < N; i++) {
+            const k = pm.generateApiKey();
+            expect(k).not.toBe('');
+            seen.add(k);
+        }
+        expect(seen.size).toBe(N);
+    });
+
+    test('entropy of 192 bits: hex body length is 48', () => {
+        const key = pm.generateApiKey();
+        const body = key.substring('sk-antigravity-'.length);
+        expect(body.length).toBe(48); // 24 bytes * 2 hex chars = 48
+    });
+
+    test('is resistant to Math.random state recovery (statistical smoke test)', () => {
+        // Observing outputs must not let us predict subsequent bytes. This
+        // isn't a formal proof, but a smoke test: the first-byte distribution
+        // over many samples should be roughly uniform across all 256 values.
+        const counts = new Array(256).fill(0);
+        const N = 5000;
+        for (let i = 0; i < N; i++) {
+            const key = pm.generateApiKey();
+            expect(key).not.toBe('');
+            const body = key.substring('sk-antigravity-'.length);
+            const firstByte = parseInt(body.substring(0, 2), 16);
+            counts[firstByte]++;
+        }
+        // Every byte value should appear at least once with N=5000 (E≈19.5).
+        const zeroCells = counts.filter(c => c === 0).length;
+        expect(zeroCells).toBeLessThan(10);
+    });
+});


### PR DESCRIPTION
## Summary

`ProxyManager.generateApiKey()` in `src/proxy/proxyManager.ts` builds the API key that authenticates callers against the local Antigravity proxy from two `Math.random().toString(36).substring(2, 15)` calls concatenated together. `Math.random()` in V8 is implemented on top of xorshift128+, whose 128-bit internal state can be reconstructed from a small number of observed outputs. Once the state is recovered, every subsequent key produced by the same VS Code session becomes deterministic to the attacker.

The generated key is meant to be **shared by design** — the dashboard's "Generate a new random API key" button (`proxyDashboardWebview.ts:2359`) is there precisely so users can paste the key into external clients that hit `http://127.0.0.1:8317/v1/chat/completions` with an `Authorization: Bearer <key>` header (see `proxyManager.ts:1312`). That means the key is a shared secret with third-party apps, and any of those third parties — if they are malicious, compromised, or leak logs — is in a position to learn the PRNG state and predict every future key the same session issues for other legitimate clients.

- **Weakness:** CWE-338 (Use of Cryptographically Weak Pseudo-Random Number Generator)
- **Affected function:** `ProxyManager.generateApiKey()` — `src/proxy/proxyManager.ts` line 497
- **Consumers:** Webview button routed via `case 'generateApiKey'` in `src/proxy/proxyDashboardWebview.ts:233-234`
- **Fix (5 lines):** replace `Math.random()` with `nodeCrypto.randomBytes(24).toString('hex')` — 192 bits from the OS CSPRNG — matching the same construction already used elsewhere in this file (`replaceDefaultApiKeys` at line 312 uses `nodeCrypto.randomBytes(8).toString('hex')`).

## Fix diff

```diff
     public generateApiKey(): string {
-        const key = 'sk-' + Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+        // Use nodeCrypto to generate a cryptographically strong API key.
+        // Math.random() is not a CSPRNG and its state (V8 xorshift128+)
+        // can be recovered from observed outputs, allowing an attacker to
+        // predict subsequent API keys used to authenticate against the proxy.
+        const key = 'sk-antigravity-' + nodeCrypto.randomBytes(24).toString('hex');
```

The `sk-antigravity-` prefix matches the convention already established by `replaceDefaultApiKeys` in the same file, so the new keys are visually consistent with the ones the extension already produces on first-run config generation.

## Why this is exploitable

Attack path:

1. User opens the proxy dashboard and clicks "Generate a new random API key". The webview posts `{ command: 'generateApiKey' }` (`proxyDashboardWebview.ts:3126-3129`), which routes to `this._proxyManager.generateApiKey()` (`proxyDashboardWebview.ts:234`). The key gets written into `bin/config.yaml` under `api-keys:` and displayed for the user to copy.
2. User pastes that key into an external client (a Python script, a browser extension, another editor plugin — whatever calls the OpenAI-compatible endpoint at `http://127.0.0.1:8317/v1/chat/completions`).
3. That external client is now in possession of one output of `Math.random()`-derived randomness. If the client is malicious, compromised, or its logs are readable by a third party, an attacker can recover the V8 xorshift128+ state (published techniques do this from ~5 outputs; a single 24-base36-char key gives ~124 bits and combined with knowledge of the base36-substring construction is generally enough).
4. Later in the same VS Code session, the user generates additional keys for other legitimate clients. The attacker predicts each of those keys deterministically.
5. Attacker connects to the loopback proxy from any process on the same host (or any external client the user has legitimately shared a key with) and issues requests with the predicted `Authorization: Bearer <predicted-key>` header. cliproxy accepts them and forwards them to the configured upstream providers — Gemini, Kimi, Qwen, Antigravity — consuming the victim's paid quota and potentially exfiltrating conversation content.

The proxy listens on `127.0.0.1` only (see the generated config template at `proxyManager.ts:370-373`: `host: "127.0.0.1"`, `allow-remote: false`), which bounds the attack surface to same-host processes and to the specific external clients the user has voluntarily shared a key with. That's a real mitigation and the reason we're treating this as a moderate-severity issue rather than critical, but it doesn't neutralise the finding — those "trusted external clients" are exactly the point of the feature.

Preconditions:

- Attacker observes at least one previously-issued API key (via a compromised client the user pasted the key into, clipboard-history capture, screenshot leak, or logs).
- Attacker can reach `127.0.0.1:8317` — either directly as a same-host process, or as an external client the user has already granted access.
- Victim generates at least one further API key in the same VS Code session after the observed one (the xorshift state persists per-session).

## Fix rationale

`nodeCrypto.randomBytes()` is the OS CSPRNG (`/dev/urandom`, `BCryptGenRandom`, etc.) and its output is not derivable from prior outputs. Twenty-four bytes yield 192 bits of entropy, matching common recommendations for bearer tokens and giving a comfortable margin above the 128-bit floor for authentication secrets.

We picked this specific construction for three reasons:

1. **Internal consistency.** The very same file already uses `nodeCrypto.randomBytes(...).toString('hex')` in `replaceDefaultApiKeys` (line 312) to rewrite the placeholder keys shipped in the default config template. Using the same primitive here means there's exactly one crypto pattern to reason about in `proxyManager.ts`.
2. **Format compatibility.** The `sk-antigravity-` prefix matches what `replaceDefaultApiKeys` produces, so keys generated by the two code paths are indistinguishable by shape. The value gets written into `bin/config.yaml` under `api-keys:` and read back verbatim by the cliproxy binary — hex is safe in YAML without quoting concerns.
3. **Minimal blast radius.** No new dependency (`crypto` is already imported at line 7 as `nodeCrypto`), no signature change on `generateApiKey()`, no changes elsewhere in the file, and behaviour visible to the user is identical (a longer, all-lowercase-hex key).

## Testing

- `src/test/unit/proxyManagerApiKey.test.ts` adds 5 focused unit tests: prefix + hex format, absence of any character outside `[0-9a-f]` (which would indicate the old base36 code path returned), 200-key uniqueness, correct entropy length, and a first-byte-uniformity smoke test over 5000 samples. All 5 pass locally:

  ```
  PASS src/test/unit/proxyManagerApiKey.test.ts (5.898 s)
    ProxyManager.generateApiKey (CWE-338 fix)
      ✓ key has expected sk-antigravity- prefix and 48 hex chars
      ✓ does not use predictable Math.random format (alphabet is hex only)
      ✓ generates unique high-entropy keys across many invocations
      ✓ entropy of 192 bits: hex body length is 48
      ✓ is resistant to Math.random state recovery (statistical smoke test)
  Tests: 5 passed, 5 total
  ```

- The existing Jest suite (`npm run test:unit`) continues to pass unchanged — this diff only replaces one line of key generation and adds a new test file; no existing test touches `generateApiKey()` output format.
- Manually reproduced the "before" behaviour in the Extension Development Host: clicking "Generate a new random API key" on `master` produces `sk-<12 base36 chars><12 base36 chars>` (24 chars, ~124 bits of nominal entropy but recoverable state); on this branch it produces `sk-antigravity-<48 hex chars>` (192 bits, non-recoverable). The dashboard displays and stores both formats identically.

## Proof of Concept

To reproduce on the pre-fix code (i.e. `master` before this PR):

1. Check out `master`, `npm install && npm run compile`, then launch the Extension Development Host with F5.
2. In the host window, open the "Antigravity Proxy" dashboard and click **Generate a new random API key**. Copy the resulting key (format `sk-<24 base36 chars>`).
3. From a terminal on the same machine, hit the loopback proxy with that key to confirm authentication works:
   ```bash
   curl -s -X POST http://127.0.0.1:8317/v1/chat/completions \
     -H "Authorization: Bearer sk-<pasted-key>" \
     -H "Content-Type: application/json" \
     -d '{"model":"gemini-2.5-flash","messages":[{"role":"user","content":"ping"}]}'
   ```
   The proxy responds; the key is accepted.
4. To confirm the key is `Math.random()`-derived (i.e. the vulnerable construction), evaluate the following in a Node REPL and observe the format matches:
   ```js
   'sk-' + Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15)
   ```
   (Reproduce the actual state-recovery attack against V8's xorshift128+ using any of the published proof-of-concept tools such as PwnFunction's `v8-randomness-predictor` — the specific attack code is out of scope for this PR, but the primitive is well-known and requires only a handful of observed outputs.)
5. Click **Generate a new random API key** again in the same session. On `master`, an attacker who has seen enough prior outputs can predict this value. After applying this PR, they cannot: the second key is 24 fresh bytes from the OS CSPRNG, independent of the first.

To confirm the fix takes effect, on this branch step 2 will produce a key of format `sk-antigravity-<48 lowercase hex chars>` and the unit tests in `src/test/unit/proxyManagerApiKey.test.ts` verify the format, entropy length, uniqueness, and byte distribution.

## Adversarial review

Before submitting, we tried to disprove this. The two "surely this is a non-issue" candidates worth flagging:

**"A same-UID attacker can just read `bin/config.yaml` — the key generation is irrelevant."** True for that specific threat model. If the attacker already has code execution as the user, they can read the config file directly and don't need to predict anything. But that's not the primary threat surface here. The API key is **designed to be pasted into external client apps** — that's the entire product surface exposed by the "Generate a new random API key" button in the dashboard. Once one of those external clients has the key, it is a foothold that does *not* require same-UID code execution; it only requires the client itself to be malicious, compromised, or to leak logs. Predicting subsequent keys from that foothold is a genuine escalation that reading `config.yaml` does not enable.

**"Loopback-only listening prevents this."** Loopback-only listening prevents *remote* attackers, and we've accounted for that in the severity assessment (it's why this is moderate, not critical). It does not prevent the two realistic exploitation paths: (a) any same-host process the user runs, and (b) the external clients the user has intentionally shared a key with — which is the whole point of the feature.

We also checked that the other `Math.random()` usages we can see in the codebase (`sync.ts` for an HTML element ID, `googleDrive.ts` for retry-backoff jitter) are not security-sensitive and don't need changing. The scoping of this fix to `generateApiKey()` alone is deliberate.